### PR TITLE
Fix server default port

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,8 @@ const express = require('express');
 const fetch = require('node-fetch');
 const cors = require('cors');
 const app = express();
-const PORT = process.env.PORT_BACK;
+// Use PORT_BACK or PORT env variable, defaulting to 5000 for development
+const PORT = process.env.PORT_BACK || process.env.PORT || 5000;
 const API_KEY = process.env.TMDB_API_KEY;
 
 app.use(cors());


### PR DESCRIPTION
## Summary
- add default port value for the Express backend to prevent crashes when no PORT_BACK is set

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530038cc48832494f4c983112ac9f4