### PR TITLE
Set numeric fallback port in server

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,7 @@ const express = require('express');
 const fetch = require('node-fetch');
 const cors = require('cors');
 const app = express();
-const PORT = process.env.PORT_BACK;
+const PORT = process.env.PORT_BACK || 5000;
 const API_KEY = process.env.TMDB_API_KEY;
 
 app.use(cors());


### PR DESCRIPTION
## Summary
- use `process.env.PORT_BACK || 5000` when starting server

## Testing
- `npm test --silent` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6853022fdec88324bf325b3e2bbfbd47