### PR TITLE
Fix backend start command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ TMDB_API_KEY=tu_api_key_de_tmdb
 ### 4. Iniciar el servidor backend
 
 ```bash
-node server-v2.js
+node src/server.js
 ```
 
 ### 5. Iniciar el frontend


### PR DESCRIPTION
## Summary
- update README to start backend with `node src/server.js`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853022c94c883249f6a07ab36da0f1d